### PR TITLE
fix English TN spacing around punctuation and contractions

### DIFF
--- a/build_fsts.py
+++ b/build_fsts.py
@@ -154,76 +154,72 @@ def build_en_tn():
     from tn.english.rules.ordinal import Ordinal
     from tn.english.rules.punctuation import Punctuation
     from tn.english.rules.range import Range
+    from tn.english.rules.serial import Serial
     from tn.english.rules.telephone import Telephone
     from tn.english.rules.time import Time
     from tn.english.rules.whitelist import WhiteList
     from tn.english.rules.word import Word
+    from tn.processor import Processor
 
     os.makedirs("wetext/fsts/en/tn", exist_ok=True)
 
-    cardinal = add_weight(Cardinal().tagger, 1.0)
-    ordinal = add_weight(Ordinal().tagger, 1.0)
-    decimal = add_weight(Decimal().tagger, 1.0)
-    fraction = add_weight(Fraction().tagger, 1.0)
-    date = add_weight(Date().tagger, 0.99)
-    time = add_weight(Time().tagger, 1.00)
-    measure = add_weight(Measure().tagger, 1.00)
-    money = add_weight(Money().tagger, 1.00)
-    telephone = add_weight(Telephone().tagger, 1.00)
-    electronic = add_weight(Electronic().tagger, 1.00)
-    word = add_weight(Word().tagger, 100)
-    whitelist = add_weight(WhiteList().tagger, 1.00)
-    punct = add_weight(Punctuation().tagger, 2.00)
-    rang = add_weight(Range().tagger, 1.01)
-    tagger = (
-        cardinal
-        | ordinal
-        | word
-        | date
-        | decimal
-        | fraction
-        | time
-        | measure
-        | money
-        | telephone
-        | electronic
-        | whitelist
-        | rang
-        | punct
-    ) + delete(byte.SPACE | "\u00a0").star
-    tagger.optimize().star.optimize().write("wetext/fsts/en/tn/tagger.fst")
+    p = Processor("_")
 
-    cardinal = Cardinal().verbalizer
-    ordinal = Ordinal().verbalizer
-    decimal = Decimal().verbalizer
-    fraction = Fraction().verbalizer
-    word = Word().verbalizer
-    date = Date().verbalizer
-    time = Time().verbalizer
-    measure = Measure().verbalizer
-    money = Money().verbalizer
-    telephone = Telephone().verbalizer
-    electronic = Electronic().verbalizer
-    whitelist = WhiteList().verbalizer
-    punct = Punctuation().verbalizer
-    rang = Range().verbalizer
+    cardinal = Cardinal()
+    ordinal = Ordinal(cardinal=cardinal)
+    decimal = Decimal(cardinal=cardinal)
+    fraction = Fraction(cardinal=cardinal, ordinal=ordinal)
+    punctuation = Punctuation()
+    date = Date(cardinal=cardinal, ordinal=ordinal)
+    time = Time(cardinal=cardinal)
+    measure = Measure(cardinal=cardinal, decimal=decimal, fraction=fraction, ordinal=ordinal)
+    money = Money(cardinal=cardinal, decimal=decimal)
+    telephone = Telephone()
+    electronic = Electronic(cardinal=cardinal)
+    serial = Serial(cardinal=cardinal, ordinal=ordinal)
+    word = Word(punctuation=punctuation)
+    whitelist = WhiteList()
+    rang = Range(date=date, time=time)
+
+    tagger = (
+        add_weight(cardinal.tagger, 1.0)
+        | add_weight(ordinal.tagger, 1.0)
+        | add_weight(word.tagger, 100)
+        | add_weight(date.tagger, 0.99)
+        | add_weight(decimal.tagger, 1.0)
+        | add_weight(fraction.tagger, 1.0)
+        | add_weight(time.tagger, 1.00)
+        | add_weight(measure.tagger, 1.00)
+        | add_weight(money.tagger, 1.00)
+        | add_weight(telephone.tagger, 1.00)
+        | add_weight(electronic.tagger, 1.00)
+        | add_weight(serial.tagger, 1.01)
+        | add_weight(whitelist.tagger, 1.00)
+        | add_weight(rang.tagger, 1.01)
+        | add_weight(punctuation.tagger, 2.00)
+    ).optimize() + (add_weight(punctuation.tagger, 2.00).plus | p.DELETE_SPACE)
+    tagger = (delete(" ").star + tagger.star) @ p.build_rule(delete(" "), r="[EOS]")
+    tagger.optimize().write("wetext/fsts/en/tn/tagger.fst")
+
     verbalizer = (
-        cardinal
-        | ordinal
-        | word
-        | date
-        | decimal
-        | fraction
-        | time
-        | measure
-        | money
-        | telephone
-        | electronic
-        | whitelist
-        | punct
-        | rang
-    ) + insert(" ")
-    verbalizer.optimize().star.optimize().write("wetext/fsts/en/tn/verbalizer.fst")
+        cardinal.verbalizer
+        | ordinal.verbalizer
+        | word.verbalizer
+        | date.verbalizer
+        | decimal.verbalizer
+        | fraction.verbalizer
+        | time.verbalizer
+        | measure.verbalizer
+        | money.verbalizer
+        | telephone.verbalizer
+        | electronic.verbalizer
+        | serial.verbalizer
+        | whitelist.verbalizer
+        | punctuation.verbalizer
+        | rang.verbalizer
+    ).optimize() + (punctuation.verbalizer.plus | p.INSERT_SPACE)
+    verbalizer = verbalizer.star @ p.build_rule(delete(" "), r="[EOS]")
+    verbalizer.optimize().write("wetext/fsts/en/tn/verbalizer.fst")
 
 
 def build_en_itn():


### PR DESCRIPTION
## Summary
- Sync `build_en_tn()` with latest wetextprocessing to use shared rule instances and punctuation-aware tagger/verbalizer construction
- Punctuation tokens no longer insert extra spaces (e.g. `shouldn ' t` → `shouldn't`, `So ,` → `So,`)
- Add `Serial` rule support

Before:
```
So, 100,000 merit shouldn't be a problem.
=> So ,  one hundred thousand merit shouldn ' t be a problem .
```

After:
```
So, 100,000 merit shouldn't be a problem.
=> So, one hundred thousand merit shouldn't be a problem.
```

## Test plan
- [x] Issue #8 test cases verified
- [x] Full test suite: zero regression (1068/1086, same as before)

Fixes #8